### PR TITLE
don't block for 700 seconds

### DIFF
--- a/src/mfrc522/MFRC522.py
+++ b/src/mfrc522/MFRC522.py
@@ -304,9 +304,9 @@ class MFRC522:
             self.SetBitMask(self.BitFramingReg, 0x80)
 
         # Wait for command execution (timeout)
-        i = 2000
+        i = 4
         while True:
-            time.sleep(0.35)
+            time.sleep(0.01)
             n = self.ReadReg(self.CommIrqReg)
             i -= 1
             # Break if interrupt request received or timeout


### PR DESCRIPTION
As mentioned in issue #4 , there is a `time.sleep(0.35)` in the loop waiting for a tag response. When no tag is present, it blocks the program for 700 seconds. This makes it unusable, to detect when a tag is placed on the reader, especially since, it stays blocked after a tag has appeared.

I think the sleep stems from a misunderstanding of the comments in the [Arduino_MFRC522v2](https://github.com/OSSLibraries/Arduino_MFRC522v2/) source code: There is a comment in MFRC522v2.cpp:411, that says the whole loop of 2000 iterations takes 35.7 ms (on some Arduino hardware): `// 35.7ms and nothing happened. Communication with the MFRC522 might be down.`

This implementation did sleep for 350ms on each iteration, 2000 times = 700s. I changed, it to sleep 4 times 10ms, which I guess is close enough to the intended total of 35ms.