### PR TITLE
Reasonable delay between tries in MFRC522_ToCard.

### DIFF
--- a/src/mfrc522/MFRC522.py
+++ b/src/mfrc522/MFRC522.py
@@ -306,7 +306,7 @@ class MFRC522:
         # Wait for command execution (timeout)
         i = 2000
         while True:
-            time.sleep(0.35)
+            time.sleep(0.01)
             n = self.ReadReg(self.CommIrqReg)
             i -= 1
             # Break if interrupt request received or timeout


### PR DESCRIPTION
My system is slow enough to need a few retries when reading registers, but 0.35s between them is excessive, it takes seconds to read a card with that delay in there.