### PR TITLE
Optimized tag reading flow and introduced resource cleanup methodes for BasicMFRC522 and SimpleMFRC522 classes

### DIFF
--- a/src/mfrc522/BasicMFRC522.py
+++ b/src/mfrc522/BasicMFRC522.py
@@ -1,5 +1,5 @@
 from . import MFRC522
-
+from time import sleep
 
 class BasicMFRC522:
     """
@@ -31,6 +31,7 @@ class BasicMFRC522:
         """
         id, text = self.read_no_block(trailer_block)
         while not id:
+            sleep(0.2)  # Wait 200ms before retrying to reduce CPU usage
             id, text = self.read_no_block(trailer_block)
         return id, text
 
@@ -59,6 +60,7 @@ class BasicMFRC522:
         """
         id = self.read_id_no_block()
         while not id:
+            sleep(0.2)  # Wait 200ms before retrying to reduce CPU usage
             id = self.read_id_no_block()
         return id
 
@@ -164,6 +166,7 @@ class BasicMFRC522:
 
         # Retry writing if it fails initially
         while not id:
+            sleep(0.2)  # Wait 200ms before retrying to reduce CPU usage
             id, text_in = self.write_no_block(text, trailer_block)
 
         # Return the tag ID and the written data
@@ -277,6 +280,7 @@ class BasicMFRC522:
 
         # Retry clearing the sector until it succeeds and returns a tag ID
         while not id:
+            sleep(0.2)  # Wait 200ms before retrying to reduce CPU usage
             id = self.clear_no_sector(trailer_block)
 
         # Return the tag ID

--- a/src/mfrc522/BasicMFRC522.py
+++ b/src/mfrc522/BasicMFRC522.py
@@ -19,7 +19,7 @@ class BasicMFRC522:
         self.MFRC522 = MFRC522()  # Create an instance of the MFRC522 class
         self.KEY = KEY  # Set the authentication key
 
-    def Close(self):
+    def close(self):
         """ 
         Close the MFRC522 instance to free up resources.
         """

--- a/src/mfrc522/BasicMFRC522.py
+++ b/src/mfrc522/BasicMFRC522.py
@@ -19,6 +19,12 @@ class BasicMFRC522:
         self.MFRC522 = MFRC522()  # Create an instance of the MFRC522 class
         self.KEY = KEY  # Set the authentication key
 
+    def Close(self):
+        """ 
+        Close the MFRC522 instance to free up resources.
+        """
+        self.MFRC522.Close()
+        
     def read_sector(self, trailer_block):
         """
         Read data from a sector of the RFID tag.

--- a/src/mfrc522/MFRC522.py
+++ b/src/mfrc522/MFRC522.py
@@ -1,7 +1,6 @@
 import RPi.GPIO as GPIO
 import spidev
 import logging
-import time
 
 
 class MFRC522:
@@ -306,7 +305,6 @@ class MFRC522:
         # Wait for command execution (timeout)
         i = 2000
         while True:
-            time.sleep(0.35)
             n = self.ReadReg(self.CommIrqReg)
             i -= 1
             # Break if interrupt request received or timeout

--- a/src/mfrc522/MFRC522.py
+++ b/src/mfrc522/MFRC522.py
@@ -1,6 +1,7 @@
 import RPi.GPIO as GPIO
 import spidev
 import logging
+from time import sleep
 
 
 class MFRC522:
@@ -310,7 +311,7 @@ class MFRC522:
             # Break if interrupt request received or timeout
             if i == 0 or (n & 0x01) or (n & waitIRq):
                 break
-
+            sleep(0.001)
         # Clear bit framing if command is transceive
         self.ClearBitMask(self.BitFramingReg, 0x80)
 
@@ -450,6 +451,7 @@ class MFRC522:
             i -= 1
             if not ((i != 0) and not (n & 0x04)):
                 break
+            sleep(0.001)
 
         # Read the calculated CRC value from the chip.
         pOutData = []

--- a/src/mfrc522/SimpleMFRC522.py
+++ b/src/mfrc522/SimpleMFRC522.py
@@ -1,4 +1,3 @@
-from . import MFRC522
 from . import BasicMFRC522
 from time import sleep
 
@@ -22,8 +21,9 @@ class SimpleMFRC522:
         self.KEY = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
         self.TRAILER_BLOCK = 11
         self.BasicMFRC522 = BasicMFRC522()
+        self.MFRC522 = self.BasicMFRC522.MFRC522()
         
-    def Close(self):
+    def close(self):
         """ 
         Close the MFRC522 instance to free up resources.
         """

--- a/src/mfrc522/SimpleMFRC522.py
+++ b/src/mfrc522/SimpleMFRC522.py
@@ -1,5 +1,6 @@
 from . import MFRC522
 from . import BasicMFRC522
+from time import sleep
 
 
 class SimpleMFRC522:
@@ -32,6 +33,7 @@ class SimpleMFRC522:
         """
         id, text = self.BasicMFRC522.read_no_block(self.TRAILER_BLOCK)
         while not id:
+            sleep(0.2)  # Wait 200ms before retrying to reduce CPU usage
             id, text = self.BasicMFRC522.read_no_block(self.TRAILER_BLOCK)
         return id, text
 
@@ -44,6 +46,7 @@ class SimpleMFRC522:
         """
         id = self.BasicMFRC522.read_id_no_block()
         while not id:
+            sleep(0.2)  # Wait 200ms before retrying to reduce CPU usage
             id = self.BasicMFRC522.read_id_no_block()
         return id
 
@@ -60,6 +63,7 @@ class SimpleMFRC522:
 
         id, text_in = self.BasicMFRC522.write_no_block(text, self.TRAILER_BLOCK)
         while not id:
+            sleep(0.2)  # Wait 200ms before retrying to reduce CPU usage
             id, text_in = self.BasicMFRC522.write_no_block(text, self.TRAILER_BLOCK)
         return id, text_in
 

--- a/src/mfrc522/SimpleMFRC522.py
+++ b/src/mfrc522/SimpleMFRC522.py
@@ -19,7 +19,6 @@ class SimpleMFRC522:
         Initializes a SimpleMFRC522 instance.
         """
         
-        self.MFRC522 = MFRC522()
         self.KEY = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
         self.TRAILER_BLOCK = 11
         self.BasicMFRC522 = BasicMFRC522()

--- a/src/mfrc522/SimpleMFRC522.py
+++ b/src/mfrc522/SimpleMFRC522.py
@@ -21,7 +21,7 @@ class SimpleMFRC522:
         self.KEY = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
         self.TRAILER_BLOCK = 11
         self.BasicMFRC522 = BasicMFRC522()
-        self.MFRC522 = self.BasicMFRC522.MFRC522()
+        self.MFRC522 = self.BasicMFRC522.MFRC522
         
     def close(self):
         """ 

--- a/src/mfrc522/SimpleMFRC522.py
+++ b/src/mfrc522/SimpleMFRC522.py
@@ -22,6 +22,12 @@ class SimpleMFRC522:
         self.KEY = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
         self.TRAILER_BLOCK = 11
         self.BasicMFRC522 = BasicMFRC522()
+        
+    def Close(self):
+        """ 
+        Close the MFRC522 instance to free up resources.
+        """
+        self.BasicMFRC522.Close()
     
     def read(self):
         """

--- a/src/mfrc522/SimpleMFRC522.py
+++ b/src/mfrc522/SimpleMFRC522.py
@@ -27,7 +27,7 @@ class SimpleMFRC522:
         """ 
         Close the MFRC522 instance to free up resources.
         """
-        self.BasicMFRC522.Close()
+        self.BasicMFRC522.close()
     
     def read(self):
         """


### PR DESCRIPTION
This pull request introduces resource cleanup methods and optimizes retry loops to reduce CPU usage. 
I added `Close` methods to the `BasicMFRC522` and `SimpleMFRC522` classes for proper resource management and insert short sleeps in the various retry loops that scan for RFID tags, making the code more efficient and less CPU-intensive when waiting for RFID tags.

More specifically:

- Added a `Close` method to both `BasicMFRC522` and `SimpleMFRC522` classes to allow proper cleanup of the underlying `MFRC522` instance and free up resources. 

- Inserted `sleep(0.2)` calls in all retry loops within `BasicMFRC522` and `SimpleMFRC522` methods (such as `read_sector`, `read_id`, `write_sector`, `clear_sector`, and their equivalents in `SimpleMFRC522`) to reduce CPU usage while waiting for RFID tag presence or operation completion. 

- Replaced longer `time.sleep` calls with shorter `sleep(0.001)` in retry loops inside `MFRC522` methods (`MFRC522_ToCard` and `CalulateCRC`) to reduce strain on the hardware interactions, as suggested in #10. This also solves #6 for me.