### PR TITLE
Add MIFARE_OpenUidBackdoor and UID write support for Magic MIFARE Gen2 cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 	- [Using `mfrc522.MFRC522`](#using-mfrc522-class)
 	- [Using `mfrc522.SimpleMFRC522`](#using-simplemfrc522-class)
 	- [Using `mfrc522.BasicMFRC522`](#using-basicmfrc522-class)
+- [Writing the UID (Magic MIFARE Gen2 cards)](#writing-the-uid-magic-mifare-gen2-cards)
 - [Example Code](#example-code)
 	- [Using `mfrc522.MFRC522`](#using-mfrc522-class-1)
 	- [Using `mfrc522.SimpleMFRC522`](#using-simplemfrc522-class-1)
@@ -51,7 +52,7 @@ The first block of **first sector typically holds the manufaturer's details** *(
 | 14      | 56, 57, 58, 59 |
 | 15      | 60, 61, 62, 63 |
 
-Manfacturer's details is stored in block number 0  and 
+Manfacturer's details is stored in block number 0  and
 Trailer blocks are 3, 7, 11, etc,.
 <br>
 **( Tips: It's better to not store any data in the first sector. Start from the first sector )**
@@ -61,7 +62,7 @@ Trailer blocks are 3, 7, 11, etc,.
 ## Installation
 ### 1. From PyPI (Stable)
 ```
-pip install mfrc522-python 
+pip install mfrc522-python
 ```
 ### 2. From Github ( Beta/dev version)
 ```
@@ -85,7 +86,7 @@ pip install git+https://github.com/1AdityaX/mfrc522-python
 ```py
 from mfrc522 import MFRC522
 
-reader = MFRC522() 
+reader = MFRC522()
 ```
 2. Request communication with a PICC *(Proximity Integrated Circuit Card A.K.A rfid card)* and check if the communication is established.
 ```py
@@ -104,7 +105,7 @@ if status == reader.MI_OK:
 4.  Select the tag to Authenticate and perform funtions like reading or writing data to the card.
 ```py
 reader.SelectTag(uid)
-``` 
+```
 5. Authenticate a particular sector with a key to read or write data to it.
 ```py
 trailer_block = 11
@@ -134,7 +135,7 @@ data = bytearray()
 data.extend(bytearray(text.ljust(  len(block_addrs)  *  16).encode('ascii')))
 i = 0
 for block_num in block_addrs:
-	reader.WriteTag(block_num, data[(i*16):(i+1)*16]) 
+	reader.WriteTag(block_num, data[(i*16):(i+1)*16])
 	i +=  1
 ```
 7. Once you business with the RFID card or Tag is over. Always Stop the Authenciation/communiction with the card.
@@ -142,6 +143,22 @@ for block_num in block_addrs:
 ```py
 reader.StopAuth()
 ```
+8. To overwrite block 0 (UID) on a Magic MIFARE Gen2 card, use `MIFARE_OpenUidBackdoor()` immediately before `WriteTag(0, ...)`. See the [Writing the UID](#writing-the-uid-magic-mifare-gen2-cards) section for background and the block 0 format.
+```py
+block0 = [0x67, 0xB0, 0x23, 0x2C, 0xD8, 0x08, 0x04, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+
+if reader.MIFARE_OpenUidBackdoor():
+    reader.WriteTag(0, block0)
+else:
+    print("Failed — card may not be a Magic MIFARE Gen2 card.")
+```
+
+#### `MIFARE_OpenUidBackdoor()` → `bool`
+Sends the two-byte magic command sequence required to unlock block 0 on Magic MIFARE Gen2 cards. Must be called immediately before `WriteTag(0, data)`.
+- Returns `True` if the card acknowledged the sequence.
+- Returns `False` if the card did not respond (not a Gen2 Magic card, or no card in range).
+- Has **no effect on standard MIFARE Classic cards**.
 
 ### Using `SimpleMFRC522` class
 1. Import and create an instance of class `SimpleMFRC522` from `mfrc522` module
@@ -151,7 +168,7 @@ from mfrc522 import SimpleMFRC522
 reader = SimpleMFRC522()
 ```
 2. Use `read()`  to read and `write()` to write
-**To read** 
+**To read**
 ```py
 id, text = reader.read()
 print(f"ID: {id}")
@@ -188,7 +205,26 @@ Writes the given text to an RFID tag.
 -   Args:
     -   `text` (str): A string to be written to the RFID tag.
 -   Returns: A tuple containing the ID of the tag and the text that was written to the tag.
-    
+
+#### `write_uid(uid, sak=0x08, atqa=None, manufacturer_data=None)` → `(uid_int, written_data)`
+
+Overwrites the UID of a Magic MIFARE Gen2 card. Blocks until a card is present and the write succeeds. See the [Writing the UID](#writing-the-uid-magic-mifare-gen2-cards) section for background and the block 0 format.
+
+-   Args:
+    -   `uid` (list or bytes): Exactly 4 bytes for the new UID.
+    -   `sak` (int): Select AcKnowledge byte. `0x08` = MIFARE Classic 1K (default).
+    -   `atqa` (list): 2-byte ATQA value. Defaults to `[0x04, 0x00]`.
+    -   `manufacturer_data` (list): 8 bytes appended after ATQA. Defaults to zeros.
+-   Returns: A tuple `(uid_int, written_data)` where `uid_int` is the new UID as an integer and `written_data` is the full 16-byte block 0 as written.
+
+#### `write_block0(data)` → `(uid_bytes, written_data)`
+
+Writes a raw 16-byte manufacturer block to block 0 of a Magic MIFARE Gen2 card. Use this when you need precise control over every byte (e.g., preserving a specific SAK or manufacturer byte). Blocks until a card is present and the write succeeds. See the [Writing the UID](#writing-the-uid-magic-mifare-gen2-cards) section for the block 0 format.
+
+-   Args:
+    -   `data` (list or bytes): Exactly 16 bytes to write to block 0.
+-   Returns: A tuple `(uid_bytes, written_data)` where `uid_bytes` is the first 4 bytes of the written block.
+
 ### Using `BasicMFRC522` class
 1. Import and create an instance of the class `BasicMFRC522` from `mfrc522` module
 ```py
@@ -262,7 +298,7 @@ Attempts to write data to the RFID tag without blocking.
     -   `text` (str): The data to write.
     -   `trailer_block` (int): The block number of the sector trailer.
     -   `block_addr` (tuple): The block numbers.
-    
+
 #### `clear_sector(trailer_block=11)`
 Clears a sector of the RFID tag by writing empty data to all blocks.
 -   Args:
@@ -287,10 +323,68 @@ Attempts to clear a sector of the RFID tag without blocking.
 
 **Note: Clearing a sector will permanently erase the data stored in the blocks of that sector. Use with caution as this operation cannot be undone.**
 
+#### `write_uid(uid, sak=0x08, atqa=None, manufacturer_data=None)` → `(uid_int, written_data)`
+
+Overwrites the UID of a Magic MIFARE Gen2 card. Accepts a 4-byte UID and automatically computes the BCC (XOR of the 4 UID bytes). Blocks until a card is present and the write succeeds. See the [Writing the UID](#writing-the-uid-magic-mifare-gen2-cards) section for background and the block 0 format.
+
+-   Args:
+    -   `uid` (list or bytes): Exactly 4 bytes for the new UID.
+    -   `sak` (int): Select AcKnowledge byte. `0x08` = MIFARE Classic 1K (default).
+    -   `atqa` (list): 2-byte ATQA value. Defaults to `[0x04, 0x00]`.
+    -   `manufacturer_data` (list): 8 bytes appended after ATQA. Defaults to zeros.
+-   Returns: A tuple `(uid_int, written_data)` where `uid_int` is the new UID as an integer and `written_data` is the full 16-byte block 0 as written.
+
+#### `write_uid_no_block(uid, sak=0x08, atqa=None, manufacturer_data=None)` → `(uid_int, written_data) | (None, None)`
+
+Non-blocking variant of `write_uid`. Returns `(None, None)` immediately if no card is in range or the card is not a Magic Gen2 card.
+
+#### `write_block0(data)` → `(uid_bytes, written_data)`
+
+Writes a raw 16-byte manufacturer block to block 0 of a Magic MIFARE Gen2 card. Use this when you need precise control over every byte (e.g., preserving a specific SAK or manufacturer byte). Blocks until a card is present and the write succeeds. See the [Writing the UID](#writing-the-uid-magic-mifare-gen2-cards) section for the block 0 format.
+
+-   Args:
+    -   `data` (list or bytes): Exactly 16 bytes to write to block 0.
+-   Returns: A tuple `(uid_bytes, written_data)` where `uid_bytes` is the first 4 bytes of the written block.
+
+#### `write_block0_no_block(data)` → `(uid_bytes, written_data) | (None, None)`
+
+Non-blocking variant of `write_block0`. Returns `(None, None)` immediately if no card is in range or the card is not a Magic Gen2 card.
+
+## Writing the UID (Magic MIFARE Gen2 cards)
+
+### Background
+
+Block 0 of a standard MIFARE Classic card — the block that contains the UID and manufacturer data — is **permanently write-protected** by the card manufacturer. On most cards this cannot be changed.
+
+However, there is a special class of cards often called **"Magic MIFARE"**, **"UID changeable"**, or **"Gen2"** cards, which contain a vendor backdoor that allows block 0 to be overwritten. These cards are commonly used in hobbyist and access-control cloning scenarios.
+
+To unlock block 0 on these cards you must send a two-byte magic command sequence before writing:
+
+1. `0x40` transmitted as a **7-bit frame**
+2. `0x43` transmitted as a normal **8-bit frame**
+
+This sequence is implemented by `MFRC522.MIFARE_OpenUidBackdoor()`, which was adapted from the [`MIFARE_OpenUidBackdoor()`](https://github.com/miguelbalboa/rfid/blob/master/src/MFRC522Extended.cpp) function in the popular miguelbalboa/rfid Arduino library.
+
+> **Note:** This has **no effect on standard MIFARE Classic cards**. The magic commands will simply time out and `MIFARE_OpenUidBackdoor()` will return `False`.
+
+### Block 0 format
+
+Block 0 is 16 bytes with the following layout:
+
+| Bytes | Field              | Notes                                        |
+|-------|--------------------|----------------------------------------------|
+| 0–3   | UID                | 4-byte unique identifier                     |
+| 4     | BCC                | XOR of the 4 UID bytes (computed for you)    |
+| 5     | SAK                | Select AcKnowledge — `0x08` for Classic 1K   |
+| 6–7   | ATQA               | Answer To reQuest, type A — `[0x04, 0x00]`   |
+| 8–15  | Manufacturer data  | Arbitrary; defaults to zeros                 |
+
+> **Important:** Overwriting block 0 on a Magic MIFARE Gen2 card is permanent on that write. Always verify the result by reading block 0 back afterwards. Sending the wrong BCC byte may render the card unresponsive.
+
 ## Example Code
-### Using `MFRC522` class 
+### Using `MFRC522` class
  **read.py**
- 
+
  To read a particular sector and convert the bytes to plain string/text.
 ```py
 from mfrc522 import MFRC522
@@ -370,6 +464,45 @@ while not uid:
 print(uid)
 print(text_in)
 ```
+
+**write_uid.py**
+
+To overwrite the UID on a Magic MIFARE Gen2 card using the low-level API directly.
+```py
+import time
+from mfrc522 import MFRC522
+
+reader = MFRC522()
+reader.Init()
+
+# Full 16-byte manufacturer block: UID + BCC + SAK + ATQA + manufacturer data
+# BCC = 0x67 ^ 0xB0 ^ 0x23 ^ 0x2C = 0xD8
+block0 = [0x67, 0xB0, 0x23, 0x2C, 0xD8, 0x08, 0x04, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+
+print("Place a Magic MIFARE Gen2 card on the reader...")
+
+# Wait for a card
+uid = None
+while uid is None:
+    status, _ = reader.Request(MFRC522.PICC_REQIDL)
+    if status == MFRC522.MI_OK:
+        status, uid = reader.Anticoll()
+        if status != MFRC522.MI_OK:
+            uid = None
+    time.sleep(0.1)
+
+print(f"Card detected. Current UID: {' '.join(f'{b:02X}' for b in uid)}")
+
+if reader.MIFARE_OpenUidBackdoor():
+    reader.WriteTag(0, block0)
+    print(f"Block 0 written: {' '.join(f'{b:02X}' for b in block0)}")
+else:
+    print("Failed — card may not be a Magic MIFARE Gen2 card.")
+
+reader.Close()
+```
+
 ### Using `SimpleMFRC522` class
 **read.py**
 ```py
@@ -389,9 +522,26 @@ writer = SimpleMFRC522()
 text = "Hello, world"
 
 id, text_written = writer.write(text)
-print(f"ID: {id}")  
+print(f"ID: {id}")
 print(f"Text Written: {text_written}")
 ```
+
+**write_uid.py**
+
+To overwrite the UID on a Magic MIFARE Gen2 card using the high-level API.
+```py
+from mfrc522 import SimpleMFRC522
+
+writer = SimpleMFRC522()
+
+new_uid = [0x67, 0xB0, 0x23, 0x2C]
+print("Place a Magic MIFARE Gen2 card on the reader...")
+uid_int, written = writer.write_uid(new_uid)
+print(f"New UID written: {' '.join(f'{b:02X}' for b in new_uid)}")
+
+writer.close()
+```
+
 ### Using `BasicMFRC522` class
 **read_sector.py**
 To read a particular sector
@@ -465,6 +615,43 @@ sectors  = [11, 15]
 id = writer.clear_sectors(sectors)
 print("Cleared")
 ```
+
+**write_uid.py**
+
+To overwrite the UID on a Magic MIFARE Gen2 card. The BCC byte is computed automatically.
+```py
+from mfrc522 import BasicMFRC522
+
+writer = BasicMFRC522()
+
+new_uid = [0x67, 0xB0, 0x23, 0x2C]
+print("Place a Magic MIFARE Gen2 card on the reader...")
+uid_int, written = writer.write_uid(new_uid)
+print(f"New UID written: {' '.join(f'{b:02X}' for b in new_uid)}")
+
+writer.close()
+```
+
+**write_block0.py**
+
+To write a full raw 16-byte block 0, giving precise control over every field.
+```py
+from mfrc522 import BasicMFRC522
+
+writer = BasicMFRC522()
+
+# Full 16-byte manufacturer block: UID + BCC + SAK + ATQA + manufacturer data
+# BCC = 0x67 ^ 0xB0 ^ 0x23 ^ 0x2C = 0xD8
+block0 = [0x67, 0xB0, 0x23, 0x2C, 0xD8, 0x08, 0x04, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+
+print("Place a Magic MIFARE Gen2 card on the reader...")
+uid_bytes, written = writer.write_block0(block0)
+print(f"Block 0 written: {' '.join(f'{b:02X}' for b in written)}")
+
+writer.close()
+```
+
 ## Contributions
 Contributions to the `mfrc522-python` library are welcome. To contribute, follow these steps:
 

--- a/src/mfrc522/BasicMFRC522.py
+++ b/src/mfrc522/BasicMFRC522.py
@@ -367,6 +367,89 @@ class BasicMFRC522:
             self.MFRC522.StopCrypto1()
             return None
 
+    def write_block0_no_block(self, data):
+        """
+        Attempt to write raw 16-byte data to block 0 of a Magic MIFARE Gen2 card.
+
+        Block 0 contains the UID, BCC, SAK, ATQA and manufacturer data. This
+        method uses MIFARE_OpenUidBackdoor() to unlock the write and will fail
+        silently on standard (non-magic) cards.
+
+        Args:
+            data (bytes or list): Exactly 16 bytes to write to block 0.
+
+        Returns:
+            tuple: (uid_bytes, written_data) on success, (None, None) on failure.
+                uid_bytes is the first 4 bytes of the written data (the new UID).
+        """
+        if len(data) != 16:
+            raise ValueError("Block 0 data must be exactly 16 bytes.")
+
+        if not self.MFRC522.MIFARE_OpenUidBackdoor():
+            return None, None
+
+        self.MFRC522.WriteTag(0, list(data))
+        return list(data[:4]), list(data)
+
+    def write_block0(self, data):
+        """
+        Write raw 16-byte data to block 0 of a Magic MIFARE Gen2 card, blocking
+        until successful.
+
+        See write_block0_no_block() for details.
+        """
+        uid_bytes, written = self.write_block0_no_block(data)
+        while uid_bytes is None:
+            uid_bytes, written = self.write_block0_no_block(data)
+        return uid_bytes, written
+
+    def write_uid_no_block(self, uid, sak=0x08, atqa=None, manufacturer_data=None):
+        """
+        Attempt to overwrite the UID of a Magic MIFARE Gen2 card.
+
+        Constructs the full 16-byte manufacturer block from the given UID,
+        automatically computing the BCC (XOR of the 4 UID bytes) and using
+        sensible defaults for SAK, ATQA and manufacturer bytes.
+
+        Args:
+            uid (list or bytes): Exactly 4 bytes for the new UID.
+            sak (int): Select AcKnowledge byte. 0x08 = MIFARE Classic 1K (default).
+            atqa (list): 2-byte ATQA value. Defaults to [0x04, 0x00].
+            manufacturer_data (list): 8 bytes appended after ATQA. Defaults to zeros.
+
+        Returns:
+            tuple: (new_uid_int, written_data) on success, (None, None) on failure.
+                new_uid_int is the new UID as an integer (for consistency with other
+                read/write methods).
+        """
+        if len(uid) != 4:
+            raise ValueError("UID must be exactly 4 bytes.")
+        if atqa is None:
+            atqa = [0x04, 0x00]
+        if manufacturer_data is None:
+            manufacturer_data = [0x00] * 8
+
+        bcc = uid[0] ^ uid[1] ^ uid[2] ^ uid[3]
+        block0 = list(uid) + [bcc, sak] + list(atqa) + list(manufacturer_data)
+
+        uid_bytes, written = self.write_block0_no_block(block0)
+        if uid_bytes is None:
+            return None, None
+
+        uid_int = self._uid_to_num(list(uid) + [bcc])
+        return uid_int, written
+
+    def write_uid(self, uid, sak=0x08, atqa=None, manufacturer_data=None):
+        """
+        Overwrite the UID of a Magic MIFARE Gen2 card, blocking until successful.
+
+        See write_uid_no_block() for parameter details.
+        """
+        uid_int, written = self.write_uid_no_block(uid, sak, atqa, manufacturer_data)
+        while uid_int is None:
+            uid_int, written = self.write_uid_no_block(uid, sak, atqa, manufacturer_data)
+        return uid_int, written
+
     def _check_trailer_block(self, trailer_block):
         if (trailer_block+1)%4 == 0:
             return True

--- a/src/mfrc522/MFRC522.py
+++ b/src/mfrc522/MFRC522.py
@@ -653,3 +653,52 @@ class MFRC522:
 
         # Turn on the antenna
         self.AntennaOn()
+
+    def Halt(self):
+        """
+        Sends the HALT command to the PICC and returns the status.
+
+        After a successful HALT the PICC enters the HALT state and will only
+        respond to a WUPA (0x52) command. Returns MI_OK on success.
+        """
+        halt_cmd = [self.PICC_HALT, 0x00]
+        crc = self.CalulateCRC(halt_cmd)
+        halt_cmd.append(crc[0])
+        halt_cmd.append(crc[1])
+        (status, _, _) = self.MFRC522_ToCard(self.PCD_TRANSCEIVE, halt_cmd)
+        return status
+
+    def MIFARE_OpenUidBackdoor(self):
+        """
+        Opens the UID backdoor on Magic MIFARE Gen2 cards, allowing block 0
+        (which contains the UID and manufacturer data) to be overwritten.
+
+        Must be called immediately before WriteTag(0, data). After writing,
+        the card returns to normal operation.
+
+        Returns True on success, False if the card did not respond to the
+        magic commands. Only works on "UID changeable" / Magic Gen2 cards —
+        has no effect on standard MIFARE Classic cards.
+
+        Based on the MIFARE_OpenUidBackdoor() implementation in the
+        miguelbalboa/rfid Arduino library.
+        """
+        # The card must be in HALT state before accepting the magic commands.
+        self.Halt()
+        sleep(0.1)
+
+        # Magic command 1: send 0x40 as a 7-bit frame (not a full byte).
+        self.WriteReg(self.BitFramingReg, 0x07)
+        (status, _, _) = self.MFRC522_ToCard(self.PCD_TRANSCEIVE, [0x40])
+        if status != self.MI_OK:
+            self.logger.error("MIFARE_OpenUidBackdoor: magic command 1 (0x40) failed.")
+            return False
+
+        # Magic command 2: send 0x43 as a full 8-bit frame.
+        self.WriteReg(self.BitFramingReg, 0x00)
+        (status, _, _) = self.MFRC522_ToCard(self.PCD_TRANSCEIVE, [0x43])
+        if status != self.MI_OK:
+            self.logger.error("MIFARE_OpenUidBackdoor: magic command 2 (0x43) failed.")
+            return False
+
+        return True

--- a/src/mfrc522/SimpleMFRC522.py
+++ b/src/mfrc522/SimpleMFRC522.py
@@ -72,3 +72,36 @@ class SimpleMFRC522:
             id, text_in = self.BasicMFRC522.write_no_block(text, self.TRAILER_BLOCK)
         return id, text_in
 
+    def write_uid(self, uid, sak=0x08, atqa=None, manufacturer_data=None):
+        """
+        Overwrite the UID of a Magic MIFARE Gen2 card.
+
+        Blocks until a card is present and the write succeeds.
+        See BasicMFRC522.write_uid() for parameter details.
+
+        Args:
+            uid (list or bytes): Exactly 4 bytes for the new UID.
+            sak (int): Select AcKnowledge byte. 0x08 = MIFARE Classic 1K (default).
+            atqa (list): 2-byte ATQA value. Defaults to [0x04, 0x00].
+            manufacturer_data (list): 8 bytes appended after ATQA. Defaults to zeros.
+
+        Returns:
+            tuple: (new_uid_int, written_data) on success.
+        """
+        return self.BasicMFRC522.write_uid(uid, sak, atqa, manufacturer_data)
+
+    def write_block0(self, data):
+        """
+        Write raw 16-byte data to block 0 of a Magic MIFARE Gen2 card.
+
+        Blocks until a card is present and the write succeeds.
+        See BasicMFRC522.write_block0() for details.
+
+        Args:
+            data (bytes or list): Exactly 16 bytes to write to block 0.
+
+        Returns:
+            tuple: (uid_bytes, written_data) on success.
+        """
+        return self.BasicMFRC522.write_block0(data)
+


### PR DESCRIPTION
## What

Adds support for overwriting the UID (block 0) on **Magic MIFARE Gen2** cards
(also known as "UID changeable" or "Gen2" cards).

- **`MFRC522.py`** — implements `MIFARE_OpenUidBackdoor()`, adapted from the
  [`MIFARE_OpenUidBackdoor()`](https://github.com/miguelbalboa/rfid/blob/master/src/MFRC522Extended.cpp)
  function in the miguelbalboa/rfid Arduino library. Sends the two-byte magic
  sequence (`0x40` as a 7-bit frame, then `0x43` as an 8-bit frame) that unlocks
  block 0 on Gen2 cards before writing.
- **`BasicMFRC522.py`** — adds `write_uid()`, `write_uid_no_block()`,
  `write_block0()`, and `write_block0_no_block()`.
- **`SimpleMFRC522.py`** — exposes `write_uid()` and `write_block0()` as
  convenience wrappers.
- **`README.md`** — documents the new API under each class section, explains
  the Gen2 backdoor mechanism, the block 0 format, and adds example code for
  all three classes.

## Why

Block 0 of a standard MIFARE Classic card is permanently write-protected.
Gen2 Magic cards are widely used in hobbyist and access-control scenarios
where cloning or changing the UID is needed. There was no support for this
in the library previously.

## How to test

- `MIFARE_OpenUidBackdoor()` returns `True` on a Gen2 Magic card, `False` on
  a standard card or when no card is in range.
- `write_uid()` / `write_block0()` correctly overwrite block 0; verify by
  reading it back.
- Non-blocking variants return `(None, None)` immediately when no card is present.
